### PR TITLE
Fix Craigslist scraping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       PADMAPPER_MAX_LAT: 35.61064120176672
       PADMAPPER_MIN_LON: -79.2388916015625
       PADMAPPER_MIN_LAT: 36.102598376304925
-      MAX_RESULTS: 10
+      # Uncomment the following line to only pull a small set of results when developing
+      # MAX_RESULTS: 10
   db:
     image: mdillon/postgis:9.6-alpine
     volumes:

--- a/mux/craigslist.rb
+++ b/mux/craigslist.rb
@@ -3,8 +3,9 @@ module Craigslist
   @@base_url = ENV['CRAIGSLIST_URL']
 
   @results_count = 0
+
   def self.crawl
-    uri = URI(@@base_url + '/jsonsearch/apa/')
+    uri = URI(@@base_url + '/jsonsearch/apa/?map=1')
     res = Net::HTTP.get_response(uri)
     results = JSON.parse(assert_successful_response(res)).first
     survey  = Survey.create
@@ -27,6 +28,7 @@ module Craigslist
 
     results.each do |r|
       create_listing_from_result(r, survey) unless r.has_key?('GeoCluster')
+      fetch_nested(r.fetch('url'), survey) if r.has_key?('GeoCluster')
     end
   end
 


### PR DESCRIPTION
At some point last week Craigslist code changed so that the jsonsearch/apa query needed `map=1` appended to it to pull a full set of results. This updates the code to incorporate that, as well as commenting out `MAX_RESULTS` by default.