### PR TITLE
Change migration class name

### DIFF
--- a/db/migrate/20170323154500_add_uid_column_to_listings.rb
+++ b/db/migrate/20170323154500_add_uid_column_to_listings.rb
@@ -1,4 +1,4 @@
-class AddUrlColumnToListings < ActiveRecord::Migration
+class AddUidColumnToListings < ActiveRecord::Migration
   def change
   	add_column :listings, :uid, :string
   end


### PR DESCRIPTION
There's a mismatch between the filename and the class name - this just fixes that problem. Sorry I missed it in your original PR :) I do want to make sure this was just a typo, however.